### PR TITLE
Correct rewrite check

### DIFF
--- a/inc/breadcrumbs.php
+++ b/inc/breadcrumbs.php
@@ -504,7 +504,7 @@ class Breadcrumb_Trail {
 		}
 
 		/* If the post type has rewrite rules. */
-		elseif ( false !== $post_type_object->rewrite ) {
+		elseif ( false !== $post_type_object->rewrite && '' != get_option( 'permalink_structure' ) ) {
 
 			/* If 'with_front' is true, add $wp_rewrite->front to the trail. */
 			if ( $post_type_object->rewrite['with_front'] )
@@ -565,7 +565,7 @@ class Breadcrumb_Trail {
 		$taxonomy = get_taxonomy( $term->taxonomy );
 
 		/* If there are rewrite rules for the taxonomy. */
-		if ( false !== $taxonomy->rewrite ) {
+		if ( false !== $taxonomy->rewrite && '' != get_option( 'permalink_structure' ) ) {
 
 			/* If 'with_front' is true, dd $wp_rewrite->front to the trail. */
 			if ( $taxonomy->rewrite['with_front'] && $wp_rewrite->front )
@@ -642,7 +642,7 @@ class Breadcrumb_Trail {
 		/* Get the post type object. */
 		$post_type_object = get_post_type_object( get_query_var( 'post_type' ) );
 
-		if ( false !== $post_type_object->rewrite ) {
+		if ( false !== $post_type_object->rewrite && '' != get_option( 'permalink_structure' ) ) {
 
 			/* If 'with_front' is true, add $wp_rewrite->front to the trail. */
 			if ( $post_type_object->rewrite['with_front'] )


### PR DESCRIPTION
Corrects rewrite check, might not be `false`, but do not apply when the permalinks are disabled, also fixes undefined index notices

WP core checks:
- post: https://core.trac.wordpress.org/browser/tags/3.8.1/src/wp-includes/post.php#L1279
- taxonomy: https://core.trac.wordpress.org/browser/tags/3.8.1/src/wp-includes/taxonomy.php#L359
