### PR TITLE
Add false option to eliminate separator all together.

### DIFF
--- a/inc/breadcrumbs.php
+++ b/inc/breadcrumbs.php
@@ -141,7 +141,10 @@ class Breadcrumb_Trail {
 			array_push( $this->items, '<span class="trail-end">' . array_pop( $this->items ) . '</span>' );
 
 			/* Format the separator. */
-			$separator = ( !empty( $this->args['separator'] ) ? '<span class="sep">' . $this->args['separator'] . '</span>' : '<span class="sep">/</span>' );
+			if ( $this->args['separator'] === false )
+				$separator = null;
+			else
+				$separator = ( !empty( $this->args['separator'] ) ? '<span class="sep">' . $this->args['separator'] . '</span>' : '<span class="sep">/</span>' );
 
 			/* Join the individual trail items into a single string. */
 			$breadcrumb .= join( "\n\t\t\t {$separator} ", $this->items );


### PR DESCRIPTION
Sometimes having a separator is not necessary and, as such, this new option will allow users to eliminate the separator.

I originally coded this using the [new WordPress standard for braces](http://make.wordpress.org/core/handbook/coding-standards/php/#brace-style), but other items of code in that section do not use braces for single line conditionals.