### PR TITLE
Fix: deprecated notice for "_usort_terms_by_ID" in WP 4.7

### DIFF
--- a/inc/breadcrumbs.php
+++ b/inc/breadcrumbs.php
@@ -1029,7 +1029,11 @@ class Breadcrumb_Trail {
 		if ( $terms && ! is_wp_error( $terms ) ) {
 
 			// Sort the terms by ID and get the first category.
-			usort( $terms, '_usort_terms_by_ID' );
+			if ( function_exists( 'wp_list_sort' ) ) {
+				usort( $terms, 'wp_list_sort' );
+			} else {
+				usort( $terms, '_usort_terms_by_ID' );
+			}
 			$term = get_term( $terms[0], $taxonomy );
 
 			// If the category has a parent, add the hierarchy to the trail.

--- a/inc/breadcrumbs.php
+++ b/inc/breadcrumbs.php
@@ -1022,9 +1022,6 @@ class Breadcrumb_Trail {
 	 */
 	protected function add_post_terms( $post_id, $taxonomy ) {
 
-		// Get the post type.
-		$post_type = get_post_type( $post_id );
-
 		// Get the post categories.
 		$terms = get_the_terms( $post_id, $taxonomy );
 


### PR DESCRIPTION
Hi,
This is a simple fix for notice and another simple unused code fix!