### PR TITLE
Load plugin translation also when must-use

### DIFF
--- a/breadcrumb-trail.php
+++ b/breadcrumb-trail.php
@@ -14,8 +14,12 @@
 if ( !function_exists( 'breadcrumb_trail' ) )
 	require_once( 'inc/breadcrumbs.php' );
 
-# Load translation files. Note: Remove this line if packaging with a theme.
-load_plugin_textdomain( 'breadcrumb-trail', false, 'breadcrumb-trail/languages' );
+# Load translation files. Note: Remove these lines if packaging with a theme.
+if ( false !== strpos( __FILE__, basename( WPMU_PLUGIN_DIR ) ) ) {
+	load_muplugin_textdomain( 'breadcrumb-trail', 'breadcrumb-trail/languages' );
+} else {
+	load_plugin_textdomain( 'breadcrumb-trail', false, 'breadcrumb-trail/languages' );
+}
 
 # Check theme support. */
 add_action( 'after_setup_theme', 'breadcrumb_trail_theme_setup', 12 );


### PR DESCRIPTION
This PR does what the title says. Basically added check if plugin is must-use and if, use `load_muplugin_textdomain` instead of `load_plugin_textdomain`.

I think this is something that WP core should address and do automatically, but [Trac ticket](https://core.trac.wordpress.org/ticket/23794) hasn't updated in year...